### PR TITLE
Add polygon editing for bodies

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -14,3 +14,6 @@ svg{width:100%;height:100%;background:#fff;}
 .h-handle{fill:#0074d9;cursor:ew-resize;}
 .special-placeholder{fill:none;stroke:red;stroke-dasharray:3 2;}
 .special-form{fill:rgba(255,165,0,0.3);stroke:#ff9800;stroke-dasharray:4 2;cursor:pointer;}
+.body-shape{pointer-events:auto;}
+.body-shape.selected{stroke:#0074d9;stroke-width:2;fill-opacity:.8;}
+.vertex-handle{fill:#00f;cursor:move;}


### PR DESCRIPTION
## Summary
- create `body-shape` polygon overlays and vertex handles
- support adding symmetrical vertices when using the special feature
- update polygon points and handles during resize
- persist polygon data through import/export

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684cb78ffef4832685b8c407e3beed5d