### PR TITLE
Implement context menu with shape copy/paste

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,15 @@
   <div id="canvas_area">
     <svg id="diagramCanvas"></svg>
 
-</div>
-<script src="App.js"></script>
+    <ul id="contextMenu" class="context-menu">
+      <li id="copyColorMenu" class="context-menu-item">Copy colour</li>
+      <li id="pasteColorMenu" class="context-menu-item">Paste colour</li>
+      <li id="copyShapeMenu" class="context-menu-item">Copy shape</li>
+      <li id="pasteShapeMenu" class="context-menu-item">Paste shape</li>
+      <li id="removeBody" class="context-menu-item">Delete body</li>
+    </ul>
+
+  </div>
+  <script src="App.js"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -17,6 +17,7 @@ svg{width:100%;height:100%;background:#fff;}
 .body-shape{pointer-events:auto;}
 .body-shape.selected{stroke:#0074d9;stroke-width:2;fill-opacity:.8;}
 .vertex-handle{fill:#00f;cursor:move;}
+.handle,.h-handle,.vertex-handle{display:none;}
 .context-menu{position:absolute;display:none;background:#fff;border:1px solid #ccc;list-style:none;padding:0;margin:0;z-index:1000;}
 .context-menu-item{padding:4px 8px;cursor:pointer;white-space:nowrap;}
 .context-menu-item:hover{background:#eee;}


### PR DESCRIPTION
## Summary
- show handles only when a body is selected
- add custom context menu with copy/paste color and shape options
- clone shapes via new helper functions
- display last updated time including clock

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684ccc0b8d248326a09b99582cb8006f