### PR TITLE
Add connector mode and zoom controls

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,12 +1,16 @@
 const svgNS = "http://www.w3.org/2000/svg";
 const canvas = document.getElementById("diagramCanvas");
-canvas.addEventListener("contextmenu", (e) => e.preventDefault());
+canvas.addEventListener("contextmenu", (e) => {
+  e.preventDefault();
+  showContextMenu(e, null);
+});
 const parts = [];
 let selectedPart = null;
 let copiedColor = null;
 let copiedShape = null;
 let contextPart = null;
 const menu = document.getElementById("contextMenu");
+let zoom = 1;
 
 const APP_VERSION = "1.0";
 document.getElementById("version").textContent = APP_VERSION;
@@ -14,6 +18,25 @@ document.getElementById("lastUpdated").textContent = new Date(document.lastModif
 
 // --- Toolbar buttons ---
 document.getElementById("addBody").addEventListener("click", addBody);
+
+const toggleConnectorBtn = document.getElementById("toggleConnector");
+let connectorMode = false;
+toggleConnectorBtn.addEventListener("click", () => {
+  connectorMode = !connectorMode;
+  toggleConnectorBtn.classList.toggle("active", connectorMode);
+});
+
+canvas.addEventListener("wheel", (e) => {
+  e.preventDefault();
+  if (e.deltaY < 0) zoom = Math.min(3, zoom + 0.1);
+  else zoom = Math.max(0.5, zoom - 0.1);
+  updateZoom();
+});
+
+function updateZoom() {
+  canvas.style.transformOrigin = "0 0";
+  canvas.style.transform = `scale(${zoom})`;
+}
 
 document.getElementById("colorPicker").addEventListener("input", (e) => {
   if (selectedPart) {
@@ -70,6 +93,13 @@ document.getElementById("pasteShapeMenu").addEventListener("click", () => {
     createPartFromData(data);
   }
   menu.style.display = "none";
+});
+
+document.getElementById("resetView").addEventListener("click", () => {
+  zoom = 1;
+  updateZoom();
+  menu.style.display = "none";
+  contextPart = null;
 });
 
 document.addEventListener("click", () => {
@@ -405,7 +435,7 @@ function createConnectorLabel(x, y) {
 function addPartEventListeners(part) {
   part.shape.addEventListener("click", (e) => {
     selectPart(part);
-    handleConnectorToggle(e, part);
+    if (connectorMode) handleConnectorToggle(e, part);
   });
   part.shape.addEventListener("dblclick", (e) => {
     selectPart(part);

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
   <div id="control_panel">
     <h2>Tools</h2>
     <button id="addBody" class="tool">Create body</button>
-    <button id="toggleConnector" class="tool" disabled>Add PIN/BOX <small>(click part ends)</small></button>
+    <button id="toggleConnector" class="tool">Add PIN/BOX <small>(click part ends)</small></button>
     <label class="tool">Add colour
       <input type="color" id="colorPicker" style="width:100%;padding:0;margin-top:4px">
     </label>
@@ -34,6 +34,7 @@
       <li id="copyShapeMenu" class="context-menu-item">Copy shape</li>
       <li id="pasteShapeMenu" class="context-menu-item">Paste shape</li>
       <li id="removeBody" class="context-menu-item">Delete body</li>
+      <li id="resetView" class="context-menu-item">Reset view</li>
     </ul>
 
   </div>

--- a/styles.css
+++ b/styles.css
@@ -4,8 +4,9 @@ html,body{margin:0;height:100%;font-family:sans-serif;}
 #control_panel h2{margin:4px 0 8px;text-align:center;font-size:20px;}
 button.tool{cursor:pointer;margin:4px 0;padding:6px 8px;font-size:14px;border:1px solid #666;background:#fff;transition:background .15s;}
 button.tool:hover{background:#e9e9e9;}
+button.tool.active{background:#cde0ff;}
 label.tool{margin:4px 0;display:block;font-size:14px;cursor:pointer;}
-#canvas_area{flex:1;position:relative;}
+#canvas_area{flex:1;position:relative;overflow:auto;}
 svg{width:100%;height:100%;background:#fff;}
 .rect.selected{stroke:#0074d9;stroke-width:2;fill-opacity:.8;}
 .handle{fill:#0074d9;cursor:ns-resize;}


### PR DESCRIPTION
## Summary
- enable Add PIN/BOX tool to activate connector editing only when clicked
- allow zooming with the mouse wheel and reset from context menu
- show custom menu when right‑clicking anywhere
- style active tool button and allow canvas scrolling

## Testing
- `node -e "require('./App.js')"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_684ccf7fce0483269a01ec985da2be12