### PR TITLE
Add undo functionality with history

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,7 @@
       <li id="pasteShapeMenu" class="context-menu-item">Paste shape</li>
       <li id="setSizeMenu" class="context-menu-item">Set size</li>
       <li id="removeBody" class="context-menu-item">Delete body</li>
+      <li id="undoAction" class="context-menu-item">Undo</li>
       <li id="resetView" class="context-menu-item">Reset view</li>
     </ul>
 


### PR DESCRIPTION
## Summary
- add Undo option to the context menu
- implement undo stack for up to 15 states
- snapshot state before mutations and allow restoring previous state
- fix removing parts so remaining parts update properly

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684f2a0ccc4483269963ee851370b088