### PR TITLE
Add reference axes with scaling control

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,9 @@
     <button id="drawLine" class="tool draw-tool" data-mode="line">Draw line</button>
     <button id="drawCurve" class="tool draw-tool" data-mode="curve">Draw curve</button>
     <button id="drawCircle" class="tool draw-tool" data-mode="circle">Draw circle</button>
+    <label class="tool">Scale
+      <input type="range" id="scaleSlider" min="0.5" max="3" step="0.1" value="1" style="width:100%;margin-top:4px">
+    </label>
     <div style="flex:1"></div>
       <button id="importBtn" class="tool">Import</button>
       <input type="file" id="fileInput" accept="application/json" style="display:none">

--- a/styles.css
+++ b/styles.css
@@ -24,3 +24,4 @@ svg{width:100%;height:100%;background:#fff;}
 .context-menu-item:hover{background:#eee;}
 .drawn-shape{stroke:#000;stroke-width:2;fill:none;pointer-events:none;}
 .preview-shape{stroke-dasharray:4 2;}
+.axis-layer line,.axis-layer text{pointer-events:none;stroke:#666;fill:#666;font-size:10px;}


### PR DESCRIPTION
## Summary
- delay axis drawing until page load
- adjust axis drawing positions to keep them visible
- call updateZoom and updateAxes on load

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684f37f689dc8326876d3ea20f6bfa07