### PR TITLE
Add scale slider

### DIFF
--- a/App.js
+++ b/App.js
@@ -15,6 +15,7 @@ let copiedShape = null;
 let contextPart = null;
 const menu = document.getElementById("contextMenu");
 let zoom = 1;
+let unitScale = 1;
 const undoStack = [];
 
 let drawMode = null;
@@ -196,6 +197,16 @@ document.getElementById("pasteColor").addEventListener("click", () => {
     document.getElementById("colorPicker").value = copiedColor;
   }
 });
+
+const scaleSlider = document.getElementById("scaleSlider");
+const scaleValue = document.getElementById("scaleValue");
+if (scaleSlider) {
+  scaleSlider.addEventListener("input", () => {
+    unitScale = parseFloat(scaleSlider.value);
+    scaleValue.textContent = unitScale.toFixed(1) + "x";
+  });
+  scaleValue.textContent = unitScale.toFixed(1) + "x";
+}
 
 document.getElementById("removeBody").addEventListener("click", () => {
   if (contextPart) removePart(contextPart);
@@ -1075,7 +1086,8 @@ function parseDimension(input, defUnit) {
   }
   let val = unit === 'in' ? parseFractionalInches(s) : parseFloat(s);
   if (isNaN(val)) return NaN;
-  return unit === 'in' ? val * PX_PER_INCH : val * PX_PER_CM;
+  const base = unit === 'in' ? PX_PER_INCH : PX_PER_CM;
+  return val * base * unitScale;
 }
 
 function applyNewWidth(part, newW) {

--- a/index.html
+++ b/index.html
@@ -16,6 +16,9 @@
     </label>
       <button id="copyColor" class="tool">Copy colour</button>
     <button id="pasteColor" class="tool">Paste colour</button>
+    <label class="tool">Scale <span id="scaleValue">1x</span>
+      <input type="range" id="scaleSlider" min="0.1" max="4" step="0.1" value="1" style="width:100%;padding:0;margin-top:4px">
+    </label>
     <button id="drawLine" class="tool draw-tool" data-mode="line">Draw line</button>
     <button id="drawCurve" class="tool draw-tool" data-mode="curve">Draw curve</button>
     <button id="drawCircle" class="tool draw-tool" data-mode="circle">Draw circle</button>

--- a/styles.css
+++ b/styles.css
@@ -6,6 +6,7 @@ button.tool{cursor:pointer;margin:4px 0;padding:6px 8px;font-size:14px;border:1p
 button.tool:hover{background:#e9e9e9;}
 button.tool.active{background:#cde0ff;}
 label.tool{margin:4px 0;display:block;font-size:14px;cursor:pointer;}
+input[type=range]{width:100%;}
 #canvas_area{flex:1;position:relative;overflow:auto;}
 svg{width:100%;height:100%;background:#fff;}
 .rect.selected{stroke:#0074d9;stroke-width:2;fill-opacity:.8;}


### PR DESCRIPTION
## Summary
- let user define scale factor for unit conversions
- show slider in tools panel
- ensure range inputs take full width

## Testing
- `npm -v`

------
https://chatgpt.com/codex/tasks/task_e_684f3f52412c8326990a524c40aa0a28