### PR TITLE
Improve canvas layout

### DIFF
--- a/App.js
+++ b/App.js
@@ -14,6 +14,7 @@ let copiedColor = null;
 let copiedShape = null;
 let contextPart = null;
 const menu = document.getElementById("contextMenu");
+const canvasArea = document.getElementById("canvas_area");
 let zoom = 1;
 const undoStack = [];
 
@@ -25,6 +26,12 @@ let circleCenter = null;
 const APP_VERSION = "1.0";
 document.getElementById("version").textContent = APP_VERSION;
 document.getElementById("lastUpdated").textContent = new Date(document.lastModified).toLocaleString();
+
+function updateCanvasSize() {
+  const bottom = parts.reduce((m, p) => Math.max(m, p.y + p.height), 0);
+  const newH = Math.max(canvasArea.clientHeight, bottom + 20);
+  canvas.style.height = `${newH}px`;
+}
 
 // --- Toolbar buttons ---
 document.getElementById("addBody").addEventListener("click", addBody);
@@ -154,8 +161,12 @@ canvas.addEventListener("wheel", (e) => {
 });
 
 function updateZoom() {
+  const cx = (canvasArea.scrollLeft + canvasArea.clientWidth / 2) / zoom;
+  const cy = (canvasArea.scrollTop + canvasArea.clientHeight / 2) / zoom;
   canvas.style.transformOrigin = "0 0";
   canvas.style.transform = `scale(${zoom})`;
+  canvasArea.scrollLeft = cx * zoom - canvasArea.clientWidth / 2;
+  canvasArea.scrollTop = cy * zoom - canvasArea.clientHeight / 2;
 }
 
 function saveState() {
@@ -429,6 +440,7 @@ function addBody() {
   addPartEventListeners(part);
   toggleHandles(part, false);
   selectPart(part);
+  updateCanvasSize();
 }
 
 function exportPart(part) {
@@ -614,6 +626,7 @@ function createPartFromData(p) {
   updateVertexHandles(partData);
   addPartEventListeners(partData);
   toggleHandles(partData, false);
+  updateCanvasSize();
   return partData;
 }
 
@@ -1117,6 +1130,7 @@ function updatePartHeight(part, newH) {
     }
     baseY += parts[i].height;
   }
+  updateCanvasSize();
 }
 
 // --- Polygon Shape Helpers ---
@@ -1234,6 +1248,7 @@ function removePart(part) {
     updateVertexHandles(p);
     baseY += p.height;
   }
+  updateCanvasSize();
 }
 
 function showContextMenu(e, part) {
@@ -1282,6 +1297,7 @@ function clearCanvas() {
   drawLayer.innerHTML = '';
   selectedPart = null;
   canvas.appendChild(drawLayer);
+  updateCanvasSize();
 }
 function loadFromData(data) {
   clearCanvas();
@@ -1296,7 +1312,9 @@ function loadFromData(data) {
     });
     drawnShapes.push(...data.drawnShapes);
   }
+  updateCanvasSize();
 }
 
 // capture initial empty state
 saveState();
+updateCanvasSize();


### PR DESCRIPTION
## Summary
- resize canvas dynamically when parts change
- keep canvas centered when zooming

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684f46f412a48326a1580a544923bba5