### PR TITLE
Improve zoom controls

### DIFF
--- a/App.js
+++ b/App.js
@@ -73,6 +73,14 @@ function setDrawMode(mode) {
 document.getElementById('drawLine').addEventListener('click', () => setDrawMode('line'));
 document.getElementById('drawCurve').addEventListener('click', () => setDrawMode('curve'));
 document.getElementById('drawCircle').addEventListener('click', () => setDrawMode('circle'));
+document.getElementById('zoomIn').addEventListener('click', () => {
+  zoom = Math.min(3, zoom + 0.1);
+  updateZoom();
+});
+document.getElementById('zoomOut').addEventListener('click', () => {
+  zoom = Math.max(0.01, zoom - 0.1);
+  updateZoom();
+});
 
 function handleCanvasClick(e) {
   if (!drawMode) return;
@@ -166,12 +174,15 @@ function handleMouseMove(e) {
   }
 }
 
-canvas.addEventListener("wheel", (e) => {
+function handleWheel(e) {
   e.preventDefault();
   if (e.deltaY < 0) zoom = Math.min(3, zoom + 0.1);
   else zoom = Math.max(0.01, zoom - 0.1);
   updateZoom();
-});
+}
+
+document.addEventListener("wheel", handleWheel, { passive: false });
+window.addEventListener("resize", centerDiagram);
 
 function updateZoom() {
   canvas.style.transformOrigin = "0 0";

--- a/index.html
+++ b/index.html
@@ -19,6 +19,8 @@
     <button id="drawLine" class="tool draw-tool" data-mode="line">Draw line</button>
     <button id="drawCurve" class="tool draw-tool" data-mode="curve">Draw curve</button>
     <button id="drawCircle" class="tool draw-tool" data-mode="circle">Draw circle</button>
+    <button id="zoomIn" class="tool">Zoom in</button>
+    <button id="zoomOut" class="tool">Zoom out</button>
     <div style="flex:1"></div>
       <button id="importBtn" class="tool">Import</button>
       <input type="file" id="fileInput" accept="application/json" style="display:none">


### PR DESCRIPTION
## Summary
- allow zooming from anywhere on the page
- keep diagram centered on resize
- provide Zoom in/Zoom out buttons in toolbar

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684f50ec90b083269aaea35cac48ecfb