### PR TITLE
Add measurement axes

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -24,3 +24,5 @@ svg{width:100%;height:100%;background:#fff;}
 .context-menu-item:hover{background:#eee;}
 .drawn-shape{stroke:#000;stroke-width:2;fill:none;pointer-events:none;}
 .preview-shape{stroke-dasharray:4 2;}
+.axis-line{stroke:#000;}
+.axis-label{font-size:10px;fill:#000;dominant-baseline:middle;}


### PR DESCRIPTION
## Summary
- add axis layer to display measurement rulers
- compute inches and centimeters scales relative to diagram
- keep axes in sync when canvas resizes
- style axes with CSS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684f557f99988326b9fa0d4a7a481eda