### PR TITLE
Fix canvas clipping when expanding width

### DIFF
--- a/App.js
+++ b/App.js
@@ -48,6 +48,8 @@ function updateCanvasSize() {
   const newW = Math.max(canvasArea.clientWidth, right + 40);
   canvas.style.height = `${newH}px`;
   canvas.style.width = `${newW}px`;
+  canvas.setAttribute('height', newH);
+  canvas.setAttribute('width', newW);
   centerDiagram();
   updateAxes();
 }


### PR DESCRIPTION
## Summary
- update `updateCanvasSize` to also set SVG width/height attributes

This ensures parts wider than the default 300x150 viewport remain visible instead of being clipped by the SVG viewport.

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68508233c6808326a43bedb26b6e64f7