### PR TITLE
Enable editing of lines and circles

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -22,7 +22,8 @@ svg{width:100%;height:100%;background:#fff;}
 .context-menu{position:absolute;display:none;background:#fff;border:1px solid #ccc;list-style:none;padding:0;margin:0;z-index:1000;}
 .context-menu-item{padding:4px 8px;cursor:pointer;white-space:nowrap;}
 .context-menu-item:hover{background:#eee;}
-.drawn-shape{stroke:#000;stroke-width:2;fill:none;pointer-events:none;}
+.drawn-shape{stroke:#000;stroke-width:2;fill:none;pointer-events:all;cursor:pointer;}
+.drawn-shape.selected{stroke:#0074d9;}
 .preview-shape{stroke-dasharray:4 2;}
 .axis-line{stroke:#000;}
 .axis-label{font-size:10px;fill:#000;dominant-baseline:middle;}


### PR DESCRIPTION
## Summary
- allow adjusting line width on double-click of draw buttons
- make drawn shapes interactive
- support dragging/resizing/removing lines and circles

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685196b749608326923a2b1459db245d