### PR TITLE
Update connector template

### DIFF
--- a/App.js
+++ b/App.js
@@ -32,6 +32,25 @@ let snapEnabled = false;
 let snapIndicator = null;
 let shapeStrokeWidth = 2;
 
+const CONNECTOR_TEMPLATE = {
+  width: 432,
+  height: 372,
+  lines: [
+    { relX1: -0.00328808922558913, relY1: -0.003148066902194428, relX2: 1.0733901515151516, relY2: 0.1003465567537196 },
+    { relX1: -0.07841435185185185, relY1: 0.08241522733045466, relX2: 1.0648148148148149, relY2: 0.196998560663788 },
+    { relX1: -0.06586199294532603, relY1: 0.1825496359326052, relX2: 1.05890376984127, relY2: 0.29108458216916444 },
+    { relX1: -0.04861111111111164, relY1: 0.3918910337820676, relX2: 1.041666666666666, relY2: 0.507866456209103 },
+    { relX1: -0.0434165564373901, relY1: 0.49128939527720333, relX2: 1.0336337081128748, relY2: 0.6045766456612279 },
+    { relX1: -0.03352347883597944, relY1: 0.5951360414625592, relX2: 1.0233548280423277, relY2: 0.7219921602541618 },
+    { relX1: -0.023148148148148674, relY1: 0.6969985606637881, relX2: 1.0119047619047612, relY2: 0.8296150481189852 },
+    { relX1: -0.018490961199294935, relY1: 0.7981410337820675, relX2: 1.002783289241622, relY2: 0.9345977670129944 },
+    { relX1: -0.05890376984127033, relY1: 0.2863802810938957, relX2: 1.0480324074074068, relY2: 0.3982754423842183 },
+    { relX1: -0.010921466650633196, relY1: 0.9020836861118167, relX2: 0.8100060626102292, relY2: 0.9984738550826306 },
+  ],
+};
+
+const TRAPEZOID_RATIO = 0.08; // default side taper ratio for new bodies
+
 snapIndicator = document.createElementNS(svgNS, 'circle');
 snapIndicator.setAttribute('r', 4);
 snapIndicator.setAttribute('fill', 'none');
@@ -589,8 +608,12 @@ function addBody() {
   };
   parts.push(part);
   addPartEventListeners(part);
-  // add default corner vertices for easier dragging
-  addCornerVertices(part);
+  // create default trapezoid vertices
+  const topV = createVertexHandle(part, 0);
+  createVertexHandle(part, height);
+  topV.dx = width * TRAPEZOID_RATIO;
+  updatePolygonShape(part);
+  updateVertexHandles(part);
   // select the new part so all handles are visible
   selectPart(part);
   updateCanvasSize();
@@ -782,6 +805,10 @@ function createPartFromData(p) {
   updateVertexHandles(partData);
   addPartEventListeners(partData);
   toggleHandles(partData, false);
+  if (partData.topConnector && partData.topConnector !== 'none')
+    createConnector(partData, 'top', partData.topConnector);
+  if (partData.bottomConnector && partData.bottomConnector !== 'none')
+    createConnector(partData, 'bottom', partData.bottomConnector);
   updateCanvasSize();
   return partData;
 }
@@ -820,6 +847,12 @@ function applyShapeToPart(part, data) {
   updateConnectorLabelClass(part.topLabel, part.topConnector);
   part.bottomLabel.textContent = labelFor(part.bottomConnector);
   updateConnectorLabelClass(part.bottomLabel, part.bottomConnector);
+  if (part.topConnector && part.topConnector !== 'none')
+    createConnector(part, 'top', part.topConnector);
+  else removeConnector(part, 'top');
+  if (part.bottomConnector && part.bottomConnector !== 'none')
+    createConnector(part, 'bottom', part.bottomConnector);
+  else removeConnector(part, 'bottom');
 
   part.special = data.special;
   if (part.special) {
@@ -987,10 +1020,14 @@ function handleConnectorToggle(evt, part) {
     part.topConnector = nextState(part.topConnector);
     part.topLabel.textContent = labelFor(part.topConnector);
     updateConnectorLabelClass(part.topLabel, part.topConnector);
+    if (part.topConnector === 'none') removeConnector(part, 'top');
+    else createConnector(part, 'top', part.topConnector);
   } else if (y > rectY + h - 10) {
     part.bottomConnector = nextState(part.bottomConnector);
     part.bottomLabel.textContent = labelFor(part.bottomConnector);
     updateConnectorLabelClass(part.bottomLabel, part.bottomConnector);
+    if (part.bottomConnector === 'none') removeConnector(part, 'bottom');
+    else createConnector(part, 'bottom', part.bottomConnector);
   }
 }
 function nextState(s) {
@@ -1189,6 +1226,7 @@ function doResize(e) {
   updatePolygonShape(resizePart);
   updateVertexHandles(resizePart);
   updateAttachedShapes(resizePart);
+  updateConnectors(resizePart);
 
   const idx = parts.indexOf(resizePart);
   let baseY = resizePart.y + newH;
@@ -1204,6 +1242,7 @@ function doResize(e) {
       parts[i].specialIcon.setAttribute("y", baseY + parts[i].height / 2 - 7);
     }
     updateAttachedShapes(parts[i]);
+    updateConnectors(parts[i]);
     baseY += parts[i].height;
   }
 }
@@ -1223,7 +1262,8 @@ let hResizing = false,
   startWidth = 0,
   hResizePart = null,
   hDir = "left",
-  centerX = 0;
+  centerX = 0,
+  startDxList = null;
 function startHResize(e, part, dir) {
   e.preventDefault();
   saveState();
@@ -1233,6 +1273,7 @@ function startHResize(e, part, dir) {
   hResizePart = part;
   hDir = dir;
   centerX = part.x + part.width / 2;
+  startDxList = part.symVertices ? part.symVertices.map(v => v.dx) : null;
   window.addEventListener("mousemove", doHResize);
   window.addEventListener("touchmove", doHResize, { passive: false });
   window.addEventListener("mouseup", stopHResize);
@@ -1245,6 +1286,12 @@ function doHResize(e) {
   const newW = Math.max(30, startWidth + delta * 2);
   hResizePart.width = newW;
   hResizePart.x = centerX - newW / 2;
+  if (hResizePart.symVertices && startDxList) {
+    const scale = newW / startWidth;
+    hResizePart.symVertices.forEach((v, i) => {
+      v.dx = startDxList[i] * scale;
+    });
+  }
   updatePartWidth(hResizePart);
 }
 function stopHResize() {
@@ -1253,6 +1300,7 @@ function stopHResize() {
   window.removeEventListener("touchmove", doHResize);
   window.removeEventListener("mouseup", stopHResize);
   window.removeEventListener("touchend", stopHResize);
+  startDxList = null;
   updateCanvasSize();
 }
 
@@ -1272,6 +1320,7 @@ function updatePartWidth(part) {
   updatePolygonShape(part);
   updateVertexHandles(part);
   updateAttachedShapes(part);
+  updateConnectors(part);
 }
 
 // -- Dimension Helpers --
@@ -1350,10 +1399,18 @@ function stripShape(s) {
 function applyNewWidth(part, newW) {
   saveState();
   const center = part.x + part.width / 2;
+  const oldW = part.width;
+  const scale = newW / oldW;
   part.width = newW;
   part.x = center - newW / 2;
+  if (part.symVertices) {
+    part.symVertices.forEach((v) => {
+      v.dx *= scale;
+    });
+  }
   updatePartWidth(part);
   updateAttachedShapes(part);
+  updateConnectors(part);
   updateCanvasSize();
 }
 
@@ -1381,6 +1438,7 @@ function updatePartHeight(part, newH) {
   updatePolygonShape(part);
   updateVertexHandles(part);
   updateAttachedShapes(part);
+  updateConnectors(part);
   const idx = parts.indexOf(part);
   let baseY = part.y + newH;
   for (let i = idx + 1; i < parts.length; i++) {
@@ -1395,6 +1453,7 @@ function updatePartHeight(part, newH) {
       parts[i].specialIcon.setAttribute('y', baseY + parts[i].height / 2 - 7);
     }
     updateAttachedShapes(parts[i]);
+    updateConnectors(parts[i]);
     baseY += parts[i].height;
   }
   updateCanvasSize();
@@ -1576,12 +1635,70 @@ function detachShapeFromPart(shape) {
   delete shape.relP2;
 }
 
+function removeConnector(part, pos) {
+  if (!part.connectors || !part.connectors[pos]) return;
+  const c = part.connectors[pos];
+  if (c.group) c.group.remove();
+  delete part.connectors[pos];
+}
+
+function createConnector(part, pos, type) {
+  if (!part.connectors) part.connectors = {};
+  removeConnector(part, pos);
+
+  const w = part.width * 0.9;
+  const h = (CONNECTOR_TEMPLATE.height / CONNECTOR_TEMPLATE.width) * w;
+  const flip = (pos === 'top' && type === 'PIN') || (pos === 'bottom' && type === 'BOX');
+  const x0 = part.x + (part.width - w) / 2;
+  let y0;
+  if (pos === 'top') y0 = type === 'PIN' ? part.y - h : part.y;
+  else y0 = type === 'PIN' ? part.y + part.height : part.y + part.height - h;
+
+  const g = document.createElementNS(svgNS, 'g');
+  g.classList.add('connector-shape');
+
+  const rect = document.createElementNS(svgNS, 'rect');
+  rect.setAttribute('x', x0);
+  rect.setAttribute('y', y0);
+  rect.setAttribute('width', w);
+  rect.setAttribute('height', h);
+  rect.setAttribute('fill', '#cccccc');
+  if (type === 'BOX') rect.setAttribute('fill-opacity', '0.8');
+  g.appendChild(rect);
+
+  CONNECTOR_TEMPLATE.lines.forEach((t) => {
+    const line = document.createElementNS(svgNS, 'line');
+    const y1 = flip ? 1 - t.relY1 : t.relY1;
+    const y2 = flip ? 1 - t.relY2 : t.relY2;
+    line.setAttribute('x1', x0 + t.relX1 * w);
+    line.setAttribute('y1', y0 + y1 * h);
+    line.setAttribute('x2', x0 + t.relX2 * w);
+    line.setAttribute('y2', y0 + y2 * h);
+    line.setAttribute('stroke', 'black');
+    line.setAttribute('stroke-width', 2);
+    g.appendChild(line);
+  });
+
+  drawLayer.appendChild(g);
+  part.connectors[pos] = { type, group: g };
+}
+
+function updateConnectors(part) {
+  if (!part.connectors) return;
+  if (part.connectors.top) createConnector(part, 'top', part.connectors.top.type);
+  if (part.connectors.bottom) createConnector(part, 'bottom', part.connectors.bottom.type);
+}
+
 function removePart(part) {
   saveState();
   const idx = parts.indexOf(part);
   if (idx === -1) return;
   if (part.shapes) {
     part.shapes.forEach((s) => detachShapeFromPart(s));
+  }
+  if (part.connectors) {
+    removeConnector(part, 'top');
+    removeConnector(part, 'bottom');
   }
   canvas.removeChild(part.g);
   parts.splice(idx, 1);
@@ -1609,6 +1726,7 @@ function removePart(part) {
     updatePolygonShape(p);
     updateVertexHandles(p);
     updateAttachedShapes(p);
+    updateConnectors(p);
     baseY += p.height;
   }
   updateCanvasSize();

--- a/styles.css
+++ b/styles.css
@@ -12,6 +12,7 @@ svg{width:100%;height:100%;background:#fff;}
 .handle{fill:#0074d9;cursor:ns-resize;}
 .connector-label{font-size:10px;text-anchor:middle;dominant-baseline:middle;pointer-events:none;fill:#333;}
 .connector-label.active{font-size:12px;font-weight:bold;fill:#d00;}
+.connector-shape{pointer-events:none;}
 .h-handle{fill:#0074d9;cursor:ew-resize;}
 .special-placeholder{fill:none;stroke:red;stroke-dasharray:3 2;}
 .special-form{fill:rgba(255,165,0,0.3);stroke:#ff9800;stroke-dasharray:4 2;cursor:pointer;}


### PR DESCRIPTION
## Summary
- replace connector template with new NC50 JSON coordinates
- prevent user interaction with connector graphics
- create bodies as trapezoids by default
- scale vertices when bodies are resized

## Testing
- `node --check App.js`


------
https://chatgpt.com/codex/tasks/task_e_6851efdadf608326916f3e0b211477ba