### PR TITLE
Fix gradient visibility issue on undo

### DIFF
--- a/App.js
+++ b/App.js
@@ -2281,8 +2281,10 @@ function clearCanvas() {
   drawLayer.innerHTML = '';
   axisLayer.innerHTML = '';
   selectedPart = null;
+  canvas.appendChild(defs);
   canvas.appendChild(drawLayer);
   canvas.appendChild(axisLayer);
+  canvas.appendChild(uiLayer);
   updateCanvasSize();
 }
 function loadFromData(data) {


### PR DESCRIPTION
## Summary
- ensure `<defs>` and UI layer are restored when clearing the canvas

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_685a184f44f08326b04a11342bea2641