### PR TITLE
Add description label and name exports accordingly

### DIFF
--- a/App.js
+++ b/App.js
@@ -485,7 +485,9 @@ document.getElementById("exportBtn").addEventListener("click", () => {
   });
   const a = document.createElement("a");
   a.href = URL.createObjectURL(blob);
-  a.download = "diagram.json";
+  const safeName = (partNameInput.value.trim() || "diagram")
+    .replace(/[^a-z0-9_-]/gi, "_");
+  a.download = `${safeName}.json`;
   a.click();
 });
 

--- a/index.html
+++ b/index.html
@@ -21,8 +21,11 @@
     <button id="drawCircle" class="tool draw-tool" data-mode="circle">Draw circle</button>
     <button id="zoomIn" class="tool">Zoom in</button>
     <button id="zoomOut" class="tool">Zoom out</button>
-    <input id="partName" class="tool" type="text" placeholder="Part name" style="box-sizing:border-box;margin-top:4px">
     <div style="flex:1"></div>
+    <label class="tool" style="display:flex;flex-direction:column;">
+      <span>Description:</span>
+      <input id="partName" type="text" placeholder="Description" style="box-sizing:border-box;margin-top:4px">
+    </label>
       <button id="importBtn" class="tool">Import</button>
       <input type="file" id="fileInput" accept="application/json" style="display:none">
       <button id="exportBtn" class="tool">Export</button>


### PR DESCRIPTION
## Summary
- reposition naming field near the import/export buttons
- label the field as Description and use its value for exported filenames

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_685acd1aa0b48326bfe03ceef90a8b81