### PR TITLE
Fix remove body on imported diagrams

### DIFF
--- a/App.js
+++ b/App.js
@@ -1963,7 +1963,9 @@ function removePart(part) {
     removeConnector(part, 'top');
     removeConnector(part, 'bottom');
   }
-  canvas.removeChild(part.g);
+  if (part.g && part.g.parentNode) {
+    part.g.parentNode.removeChild(part.g);
+  }
   parts.splice(idx, 1);
   if (selectedPart === part) selectedPart = null;
   let baseY = idx > 0 ? parts[idx - 1].y + parts[idx - 1].height : TOP_MARGIN;


### PR DESCRIPTION
## Summary
- ensure body groups are removed from their actual parent when deleting

## Testing
- `npm test` *(fails: could not find package.json and network access is restricted)*

------
https://chatgpt.com/codex/tasks/task_e_685ad53806b88326b332e12f54fecbfd