### PR TITLE
Add Finished button with opener messaging

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
       <button id="importBtn" class="tool">Import</button>
       <input type="file" id="fileInput" accept="application/json" style="display:none">
       <button id="exportBtn" class="tool">Export</button>
+      <button id="finishedBtn" class="tool finished-btn" style="display:none">Finished</button>
       <div id="info" class="tool" style="text-align:center;font-size:12px;padding-top:6px;">
         Last update: <span id="lastUpdated"></span><br>
         Version: <span id="version"></span>

--- a/styles.css
+++ b/styles.css
@@ -29,3 +29,5 @@ svg{width:100%;height:100%;background:#fff;}
 .preview-shape{stroke-dasharray:4 2;}
 .axis-line{stroke:#000;}
 .axis-label{font-size:10px;fill:#000;dominant-baseline:middle;}
+.finished-btn{background:#4caf50;border-color:#4caf50;color:#fff;}
+.finished-btn:hover{background:#45a049;}


### PR DESCRIPTION
## Summary
- show a Finished button only when opened from another window
- style the Finished button
- export to the opener window on export and on Finished button click

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685c695618848326985d252ac3585833