### PR TITLE
Enable FDiagram edit messaging

### DIFF
--- a/App.js
+++ b/App.js
@@ -32,6 +32,17 @@ const launchedFromFDiagram = !!window.opener;
 if (launchedFromFDiagram) {
   finishedBtn.style.display = "block";
 }
+
+// Listen for edit requests from an opener (e.g. FDiagram)
+window.addEventListener('message', (e) => {
+  if (window.opener && e.source === window.opener) {
+    const msg = e.data || {};
+    if (msg.type === 'editComponent' && msg.component) {
+      saveState();
+      loadFromData(msg.component);
+    }
+  }
+});
 let zoom = 1;
 let verticalScaleIndex = 0;
 function updateVerticalScaleIndex() {


### PR DESCRIPTION
## Summary
- load components from `editComponent` messages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866ec3d4f988326a76d7f850358cc56