### PR TITLE
Fix centering when editing from FDiagram

### DIFF
--- a/App.js
+++ b/App.js
@@ -2427,7 +2427,10 @@ function loadFromData(data) {
     });
   }
   updateCanvasSize();
-  if (launchedFromFDiagram) centerDiagram();
+  if (launchedFromFDiagram) {
+    centerDiagram();
+    requestAnimationFrame(centerDiagram);
+  }
   ensureTopConnectorVisible();
 }
 


### PR DESCRIPTION
## Summary
- ensure diagrams loaded from FDiagram are centered after DOM updates

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686bd04ee2b08326936a0a50c22a545d