### PR TITLE
Fix centering when loading components

### DIFF
--- a/App.js
+++ b/App.js
@@ -2407,6 +2407,10 @@ function clearCanvas() {
   zoomLayer.innerHTML = '';
   axisLayer.innerHTML = '';
   selectedPart = null;
+  canvas.style.marginLeft = '0px';
+  canvasArea.scrollLeft = 0;
+  canvasArea.scrollTop = 0;
+  lastScrollTop = 0;
   canvas.appendChild(defs);
   canvas.appendChild(zoomLayer);
   zoomLayer.appendChild(drawLayer);
@@ -2441,7 +2445,10 @@ function loadFromData(data) {
     });
   }
   updateCanvasSize();
-  if (launchedFromFDiagram) centerDiagram();
+  if (launchedFromFDiagram) {
+    centerDiagram();
+    requestAnimationFrame(centerDiagram);
+  }
   ensureTopConnectorVisible();
 }
 


### PR DESCRIPTION
## Summary
- reset scroll position and margin when clearing the canvas
- ensure centering runs after layout when loading data from FDiagram

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_686bf2e8a7f4832683449cb067039a0d