### PR TITLE
Refresh diagram after import from FDiagram

### DIFF
--- a/App.js
+++ b/App.js
@@ -2459,6 +2459,9 @@ function loadFromData(data) {
   }
   ensureTopConnectorVisible();
   refreshDiagram();
+  // Perform another refresh on the next frame to ensure imported parts
+  // render correctly when launched from FDiagram.
+  requestAnimationFrame(refreshDiagram);
 }
 
 // capture initial empty state


### PR DESCRIPTION
## Summary
- ensure imported bodies update correctly when editing from FDiagram
- run a second diagram refresh on the next animation frame

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c2e7430b88326bffdb1ca6e76559c