### PR TITLE
Improve refresh after FDiagram import

### DIFF
--- a/App.js
+++ b/App.js
@@ -2462,6 +2462,16 @@ function loadFromData(data) {
   // Perform another refresh on the next frame to ensure imported parts
   // render correctly when launched from FDiagram.
   requestAnimationFrame(refreshDiagram);
+  if (launchedFromFDiagram) {
+    setTimeout(() => {
+      refreshDiagram();
+      if (parts.length) {
+        const p = parts[0];
+        p.shape.setAttribute('fill', p.color);
+        applyPartGradient(p);
+      }
+    }, 500);
+  }
 }
 
 // capture initial empty state


### PR DESCRIPTION
## Summary
- refresh diagram again after import from FDiagram
- recolor first part after a short delay to force gradient reset

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c303821008326a992be275472da5b