### PR TITLE
Improve live updates during drag

### DIFF
--- a/App.js
+++ b/App.js
@@ -1734,6 +1734,9 @@ function doVertexDrag(e) {
   vertex.dx = Math.max(minDx, startDx + delta);
   updatePolygonShape(part);
   updateVertexHandles(part);
+  updateAttachedShapes(part);
+  updateConnectors(part);
+  updateCanvasSize();
 }
 
 function stopVertexDrag() {
@@ -2242,6 +2245,10 @@ function doShapeDrag(e) {
     shape.elem.setAttribute('r', shape.r);
     updateShapeHandles(shape);
   }
+  if (shape.parentPart) {
+    updateShapeRelative(shape);
+  }
+  updateCanvasSize();
 }
 
 function stopShapeDrag() {


### PR DESCRIPTION
## Summary
- refresh connectors and canvas during vertex drag
- keep relative shape data current and resize canvas while dragging shapes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686c31d9ed1c83268c6479dd05727e4e