### PR TITLE
Rewrite FDiagram import

### DIFF
--- a/App.js
+++ b/App.js
@@ -32,22 +32,22 @@ canvasArea.addEventListener('scroll', () => {
 });
 const partNameInput = document.getElementById("partName");
 const finishedBtn = document.getElementById("finishedBtn");
-const launchedFromFDiagram = !!window.opener;
-const autoCenter = !launchedFromFDiagram;
-if (launchedFromFDiagram) {
-  finishedBtn.style.display = "block";
+
+// Check if a component was provided via the "component" query parameter.
+const params = new URLSearchParams(window.location.search);
+let importedComponent = null;
+if (params.has("component")) {
+  try {
+    importedComponent = JSON.parse(decodeURIComponent(params.get("component")));
+  } catch (err) {
+    console.error("Invalid component parameter", err);
+  }
 }
 
-// Listen for edit requests from an opener (e.g. FDiagram)
-window.addEventListener('message', (e) => {
-  if (window.opener && e.source === window.opener) {
-    const msg = e.data || {};
-    if (msg.type === 'editComponent' && msg.component) {
-      saveState();
-      loadFromData(msg.component);
-    }
-  }
-});
+const autoCenter = true;
+if (window.opener || importedComponent) {
+  finishedBtn.style.display = "block";
+}
 let zoom = 1;
 let verticalScaleIndex = 0;
 function updateVerticalScaleIndex() {
@@ -2453,27 +2453,27 @@ function loadFromData(data) {
     });
   }
   updateCanvasSize();
-  if (launchedFromFDiagram) {
-    centerDiagram();
-    requestAnimationFrame(centerDiagram);
-  }
+  centerDiagram();
+  requestAnimationFrame(centerDiagram);
   ensureTopConnectorVisible();
   refreshDiagram();
   // Perform another refresh on the next frame to ensure imported parts
-  // render correctly when launched from FDiagram.
+  // render correctly after all elements are attached.
   requestAnimationFrame(refreshDiagram);
-  if (launchedFromFDiagram) {
-    setTimeout(() => {
-      refreshDiagram();
-      if (parts.length) {
-        const p = parts[0];
-        p.shape.setAttribute('fill', p.color);
-        applyPartGradient(p);
-      }
-    }, 500);
-  }
+  setTimeout(() => {
+    refreshDiagram();
+    if (parts.length) {
+      const p = parts[0];
+      p.shape.setAttribute('fill', p.color);
+      applyPartGradient(p);
+    }
+  }, 500);
 }
 
 // capture initial empty state
 saveState();
 updateCanvasSize();
+if (importedComponent) {
+  saveState();
+  loadFromData(importedComponent);
+}

--- a/README.md
+++ b/README.md
@@ -2,4 +2,18 @@ Tool to create BHA components that can be exported as JSONs or transfered to BHA
 No data is saved and stored from the user.
 Application can be used at https://magnusmannes.github.io/FDrawer/
 
+### Embedding
+
+Another application can preload a component by opening the page with a
+`component` query parameter containing a URL encoded JSON object:
+
+```
+window.open('index.html?component=' +
+  encodeURIComponent(JSON.stringify(myComponent)), '_blank');
+```
+
+If an opener is present or a component was supplied this way, a **Finished**
+button will appear. Clicking it posts the updated component back to the opener
+using the `newComponent` message before closing the window.
+
 ![image](https://github.com/user-attachments/assets/7831bf8b-3fc6-44e1-bf2b-22e632ae586d)


### PR DESCRIPTION
## Summary
- remove old `window.opener` import logic
- load data from a `component` query parameter instead
- always auto-center the view
- document how to embed FDrawer using the new parameter

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c3ec6597083268910a86ed2effa2f