### PR TITLE
Support message-based component loading

### DIFF
--- a/App.js
+++ b/App.js
@@ -44,6 +44,29 @@ if (params.has("component")) {
   }
 }
 
+// Allow loading a component via window.postMessage. This enables other
+// applications like FDiagram to open the editor and send a component after
+// the window has been created.
+window.addEventListener("message", (e) => {
+  const msg = e.data;
+  let data = null;
+  if (msg && typeof msg === "object" && msg.component) {
+    data = msg.component;
+  } else if (typeof msg === "string") {
+    try {
+      data = JSON.parse(msg);
+    } catch (_) {
+      // ignore invalid JSON
+    }
+  } else if (msg && typeof msg === "object" && (msg.parts || msg.drawnShapes)) {
+    data = msg;
+  }
+  if (data) {
+    loadFromData(data);
+    finishedBtn.style.display = "block";
+  }
+});
+
 const autoCenter = true;
 if (window.opener || importedComponent) {
   finishedBtn.style.display = "block";

--- a/README.md
+++ b/README.md
@@ -16,4 +16,12 @@ If an opener is present or a component was supplied this way, a **Finished**
 button will appear. Clicking it posts the updated component back to the opener
 using the `newComponent` message before closing the window.
 
+Alternatively, the component can be sent to an already opened editor using
+`postMessage`:
+
+```
+const win = window.open('index.html', '_blank');
+win.postMessage({ component: myComponent }, '*');
+```
+
 ![image](https://github.com/user-attachments/assets/7831bf8b-3fc6-44e1-bf2b-22e632ae586d)


### PR DESCRIPTION
## Summary
- allow loading a component via `postMessage`
- document message-based embedding in README

## Testing
- `node -c App.js`

------
https://chatgpt.com/codex/tasks/task_e_686d7f2407f8832686487e73736a159c