### PR TITLE
Add auto demo after import

### DIFF
--- a/App.js
+++ b/App.js
@@ -48,6 +48,7 @@ let autoCenter = true;
 if (window.opener || importedComponent) {
   finishedBtn.style.display = "block";
 }
+let autoDemoDone = false;
 let zoom = 1;
 let verticalScaleIndex = 0;
 function updateVerticalScaleIndex() {
@@ -678,6 +679,7 @@ function addBody() {
   // select the new part so all handles are visible
   selectPart(part);
   updateCanvasSize();
+  return part;
 }
 
 function exportPart(part) {
@@ -2581,9 +2583,19 @@ function loadFromData(data, ignorePositions = false) {
 // capture initial empty state
 saveState();
 updateCanvasSize();
+
+function runAutoDemo() {
+  if (autoDemoDone) return;
+  autoDemoDone = true;
+  const part = addBody();
+  setTimeout(() => {
+    removePart(part);
+  }, 500);
+}
 if (importedComponent) {
   saveState();
   loadFromData(importedComponent, !!window.opener);
+  if (window.opener) runAutoDemo();
 }
 
 // Allow parent windows to send a component via postMessage after the page has
@@ -2596,6 +2608,7 @@ window.addEventListener('message', (event) => {
       saveState();
       loadFromData(data.component, !!window.opener);
       finishedBtn.style.display = 'block';
+      if (window.opener) runAutoDemo();
     } catch (err) {
       console.error('Failed to load component from message', err);
     }


### PR DESCRIPTION
## Summary
- return the newly created part from `addBody`
- add `runAutoDemo` helper
- trigger automatic add/remove body when a component is loaded from FDiagram

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687191358b7083268bf76ff83b9fd433